### PR TITLE
REP-39: Wire up NPO dropdown and save on Enter Details

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@ README.md
 .gitattributes
 pnpm-lock.yaml
 babel.config.js
+vendor/

--- a/api/config.ts
+++ b/api/config.ts
@@ -427,3 +427,18 @@ export async function claimTask(encryptedTaskId: string, driverId: number) {
     body: JSON.stringify({ driver_id: driverId }),
   });
 }
+
+export async function submitCompletionDetails(
+  encryptedTaskId: string,
+  data: { total_pounds_entered: string; description?: string },
+) {
+  const safeId = encodeURIComponent(encryptedTaskId);
+  return apiRequest(
+    `${BASE_URL}/api/tasks/${safeId}/update_completion_details`,
+    {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    },
+  );
+}

--- a/src/app/donation-details/[id].tsx
+++ b/src/app/donation-details/[id].tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Image,
   KeyboardAvoidingView,
@@ -13,30 +13,61 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import Toast from 'react-native-toast-message';
 import { router, Stack, useLocalSearchParams } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
+import { getPartners, submitCompletionDetails } from 'api/config';
 import dateIcon from 'assets/date.png';
 import RequiredInput from '@/components/RequiredInput/RequiredInput';
 import PhotoUpload from '../../components/PhotoUpload/PhotoUpload';
 import { styles } from '../../styles/pages/donation-details-styles';
-
-const MOCK_NPOS = [
-  { label: 'Rescuing Leftover Cuisine (RLC)', value: 'RLC' },
-  { label: 'Denver Food Rescue (DFR)', value: 'DFR' },
-  { label: 'Hollywood Food Coalition (HFC)', value: 'HFC' },
-];
 
 export default function DonationLayout() {
   const params = useLocalSearchParams<{ id?: string; location?: string }>();
   const location = params.location || 'Unknown';
   const [weight, setWeight] = useState('');
   const [selectedNPO, setSelectedNPO] = useState('');
+  const [notes, setNotes] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [npoOptions, setNpoOptions] = useState<
+    { label: string; value: string }[]
+  >([]);
   const isFormValid = weight.trim().length > 0 && selectedNPO.trim().length > 0;
 
-  const handleComplete = () => {
-    Toast.show({
-      type: 'success',
-      text1: 'Complete',
-      text2: `Donation recorded for ${location}.`,
-    });
+  useEffect(() => {
+    const fetchPartners = async () => {
+      try {
+        const partners = await getPartners();
+        const options = (partners as { id: number; name: string }[]).map(p => ({
+          label: p.name,
+          value: String(p.id),
+        }));
+        setNpoOptions(options);
+      } catch {
+        Toast.show({
+          type: 'error',
+          text1: 'Could not load recipients.',
+        });
+      }
+    };
+    fetchPartners();
+  }, []);
+
+  const handleComplete = async () => {
+    if (!params.id) return;
+    setLoading(true);
+    try {
+      await submitCompletionDetails(params.id, {
+        total_pounds_entered: weight,
+        description: notes || undefined,
+      });
+      Toast.show({ type: 'success', text1: 'Donation recorded!' });
+      router.replace('/(tabs)/my-tasks');
+    } catch {
+      Toast.show({
+        type: 'error',
+        text1: 'Could not save. Please try again.',
+      });
+    } finally {
+      setLoading(false);
+    }
   };
 
   const handleMissed = () => {
@@ -115,7 +146,7 @@ export default function DonationLayout() {
               onChangeText={setSelectedNPO}
               required
               isPicker
-              options={MOCK_NPOS}
+              options={npoOptions}
             />
 
             {/* Image upload */}
@@ -130,6 +161,8 @@ export default function DonationLayout() {
                 multiline
                 numberOfLines={4}
                 placeholder="Optional notes"
+                value={notes}
+                onChangeText={setNotes}
               />
             </View>
           </View>
@@ -144,10 +177,10 @@ export default function DonationLayout() {
         <TouchableOpacity
           style={[
             styles.completeButton,
-            !isFormValid && styles.completeButtonDisabled,
+            (!isFormValid || loading) && styles.completeButtonDisabled,
           ]}
           onPress={handleComplete}
-          disabled={!isFormValid}
+          disabled={!isFormValid || loading}
         >
           <Text style={[styles.completeText]}>Complete</Text>
         </TouchableOpacity>


### PR DESCRIPTION
## Summary
- Replace mock NPO list with real partner data from `getPartners()` API call on mount
- Add `submitCompletionDetails` function to `api/config.ts` (PATCH `/api/tasks/:id/update_completion_details`)
- Wire up Complete button to call backend, redirect to My Tasks on success, show error toast on failure
- Disable Complete button while request is in flight
- Connect notes TextInput to component state

## Test plan
- [ ] Open Enter Details on a real task — Recipient dropdown shows real partner names from the API
- [ ] Fill out weight + select recipient + tap Complete — should save and redirect to My Tasks
- [ ] Verify in Rails console: `Task.last.total_pounds_entered` is updated
- [ ] Tap Complete with no network — error toast should appear
- [ ] Button should be disabled/grayed out while request is in flight