### PR TITLE
Feat: [History] History Flow Screen

### DIFF
--- a/src/app/(tabs)/_layout.tsx
+++ b/src/app/(tabs)/_layout.tsx
@@ -104,6 +104,12 @@ export default function TabLayout() {
         }}
       />
       <Tabs.Screen
+        name="history"
+        options={{
+          href: null,
+        }}
+      />
+      <Tabs.Screen
         name="my-account"
         options={{
           title: 'Profile',

--- a/src/app/(tabs)/history.tsx
+++ b/src/app/(tabs)/history.tsx
@@ -3,10 +3,14 @@ import { Text, TouchableOpacity, View } from 'react-native';
 import historyStyles from '../../styles/tabs/history-styles';
 
 /**
- * Placeholder rows until Sprint 3 API. Later: missed/other statuses, red accents, etc.
+ * Placeholder rows until Sprint 3 API. Amber accent matches in-progress overdue cards
+ * (`my-tasks` `isOverdue`): pickup_date before today and task not complete.
  */
 type HistoryCardItem = {
   id: string;
+  pickupDate: string; // YYYY-MM-DD
+  /** Mirrors API: complete when pickup has an end time / finished flow */
+  isComplete: boolean;
   pickupLocation: string;
   npoRecipient: string;
 };
@@ -16,9 +20,18 @@ type HistoryDateGroup = {
   items: HistoryCardItem[];
 };
 
-/** Card accent + status label — all completed/green for now */
-const CARD_ACCENT_GREEN = '#71C79F';
-const STATUS_TEXT_GREEN = '#2D8A60';
+const CARD_ACCENT_GREEN = '#58AD85';
+const CARD_ACCENT_YELLOW = '#DBBC55'; // same as `my-tasks-styles` cardAccentOverdue
+const STATUS_TEXT_GREEN = '#58AD85';
+const STATUS_TEXT_YELLOW = '#DBBC55';
+
+function isPastPickupNotComplete(item: HistoryCardItem): boolean {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const pickup = new Date(`${item.pickupDate}T00:00:00`);
+  if (isNaN(pickup.getTime())) return false;
+  return pickup.getTime() < today.getTime() && !item.isComplete;
+}
 
 const PLACEHOLDER_GROUPS: HistoryDateGroup[] = [
   {
@@ -26,6 +39,8 @@ const PLACEHOLDER_GROUPS: HistoryDateGroup[] = [
     items: [
       {
         id: 'h1',
+        pickupDate: '2025-10-28',
+        isComplete: true,
         pickupLocation: 'Rockridge Cafe',
         npoRecipient: 'Hollywood Food Coalition (HFC)',
       },
@@ -36,6 +51,8 @@ const PLACEHOLDER_GROUPS: HistoryDateGroup[] = [
     items: [
       {
         id: 'h2',
+        pickupDate: '2025-10-25',
+        isComplete: false,
         pickupLocation: 'Strada Cafe',
         npoRecipient: 'Denver Food Rescue (DFR)',
       },
@@ -46,6 +63,8 @@ const PLACEHOLDER_GROUPS: HistoryDateGroup[] = [
     items: [
       {
         id: 'h3',
+        pickupDate: '2025-10-23',
+        isComplete: true,
         pickupLocation: 'Chipotle',
         npoRecipient: 'Rescuing Leftover Cuisine (RLC)',
       },
@@ -80,50 +99,63 @@ export default function HistoryHomeContent() {
             <Text style={historyStyles.dateGroupHeader}>
               {group.dateHeader}
             </Text>
-            {group.items.map(item => (
-              <View key={item.id} style={historyStyles.card}>
-                <View
-                  style={[
-                    historyStyles.cardAccent,
-                    { backgroundColor: CARD_ACCENT_GREEN },
-                  ]}
-                />
-                <View style={historyStyles.cardContent}>
-                  <View style={historyStyles.cardTopRow}>
-                    <Text
-                      style={[
-                        historyStyles.statusText,
-                        { color: STATUS_TEXT_GREEN },
-                      ]}
+            {group.items.map(item => {
+              const showAmber = isPastPickupNotComplete(item);
+              const accentColor = showAmber
+                ? CARD_ACCENT_YELLOW
+                : CARD_ACCENT_GREEN;
+              const statusColor = showAmber
+                ? STATUS_TEXT_YELLOW
+                : STATUS_TEXT_GREEN;
+              const statusLabel = showAmber ? 'Missed' : 'Completed';
+
+              return (
+                <View key={item.id} style={historyStyles.card}>
+                  <View
+                    style={[
+                      historyStyles.cardAccent,
+                      { backgroundColor: accentColor },
+                    ]}
+                  />
+                  <View style={historyStyles.cardContent}>
+                    <View style={historyStyles.cardTopRow}>
+                      <Text
+                        style={[
+                          historyStyles.statusText,
+                          { color: statusColor },
+                        ]}
+                      >
+                        {statusLabel}
+                      </Text>
+                    </View>
+
+                    <Text style={historyStyles.fieldLabel}>
+                      Pickup location
+                    </Text>
+                    <Text style={historyStyles.fieldValue}>
+                      {item.pickupLocation}
+                    </Text>
+
+                    <Text style={historyStyles.fieldLabel}>NPO Recipient</Text>
+                    <Text style={historyStyles.fieldValue}>
+                      {item.npoRecipient}
+                    </Text>
+
+                    <TouchableOpacity
+                      style={historyStyles.buttonFullWidth}
+                      activeOpacity={0.85}
+                      onPress={() => {
+                        /* Sprint 3: navigate with task id */
+                      }}
                     >
-                      Completed
-                    </Text>
+                      <Text style={historyStyles.buttonFullWidthText}>
+                        Edit donation details
+                      </Text>
+                    </TouchableOpacity>
                   </View>
-
-                  <Text style={historyStyles.fieldLabel}>Pickup location</Text>
-                  <Text style={historyStyles.fieldValue}>
-                    {item.pickupLocation}
-                  </Text>
-
-                  <Text style={historyStyles.fieldLabel}>NPO Recipient</Text>
-                  <Text style={historyStyles.fieldValue}>
-                    {item.npoRecipient}
-                  </Text>
-
-                  <TouchableOpacity
-                    style={historyStyles.buttonFullWidth}
-                    activeOpacity={0.85}
-                    onPress={() => {
-                      /* Sprint 3: navigate with task id */
-                    }}
-                  >
-                    <Text style={historyStyles.buttonFullWidthText}>
-                      Edit donation details
-                    </Text>
-                  </TouchableOpacity>
                 </View>
-              </View>
-            ))}
+              );
+            })}
           </View>
         ))
       )}

--- a/src/app/(tabs)/history.tsx
+++ b/src/app/(tabs)/history.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { Text, TouchableOpacity, View } from 'react-native';
+import historyStyles from '../../styles/tabs/history-styles';
+
+/**
+ * Placeholder rows until Sprint 3 API. Later: missed/other statuses, red accents, etc.
+ */
+type HistoryCardItem = {
+  id: string;
+  pickupLocation: string;
+  npoRecipient: string;
+};
+
+type HistoryDateGroup = {
+  dateHeader: string;
+  items: HistoryCardItem[];
+};
+
+/** Card accent + status label — all completed/green for now */
+const CARD_ACCENT_GREEN = '#71C79F';
+const STATUS_TEXT_GREEN = '#2D8A60';
+
+const PLACEHOLDER_GROUPS: HistoryDateGroup[] = [
+  {
+    dateHeader: '28 October, 2025',
+    items: [
+      {
+        id: 'h1',
+        pickupLocation: 'Rockridge Cafe',
+        npoRecipient: 'Hollywood Food Coalition (HFC)',
+      },
+    ],
+  },
+  {
+    dateHeader: '25 October, 2025',
+    items: [
+      {
+        id: 'h2',
+        pickupLocation: 'Strada Cafe',
+        npoRecipient: 'Denver Food Rescue (DFR)',
+      },
+    ],
+  },
+  {
+    dateHeader: '23 October, 2025',
+    items: [
+      {
+        id: 'h3',
+        pickupLocation: 'Chipotle',
+        npoRecipient: 'Rescuing Leftover Cuisine (RLC)',
+      },
+    ],
+  },
+];
+
+/** Set to true to preview empty state layout */
+const SHOW_EMPTY_STATE = false;
+
+/**
+ * History list for Home — imported by `my-tasks.tsx` when the In Progress / History
+ * toggle is on History (placeholder data until Sprint 3).
+ *
+ * This file lives under `(tabs)` for sprint organization. It is registered as a
+ * hidden tab route (`href: null` in `_layout.tsx`) so it does not add a tab bar item.
+ */
+export default function HistoryHomeContent() {
+  const groups = SHOW_EMPTY_STATE ? [] : PLACEHOLDER_GROUPS;
+
+  return (
+    <View style={historyStyles.taskSection}>
+      {groups.length === 0 ? (
+        <View style={historyStyles.emptyStateContainer}>
+          <Text style={historyStyles.emptyTitle}>
+            No history yet. Completed and missed pickups will appear here.
+          </Text>
+        </View>
+      ) : (
+        groups.map(group => (
+          <View key={group.dateHeader}>
+            <Text style={historyStyles.dateGroupHeader}>
+              {group.dateHeader}
+            </Text>
+            {group.items.map(item => (
+              <View key={item.id} style={historyStyles.card}>
+                <View
+                  style={[
+                    historyStyles.cardAccent,
+                    { backgroundColor: CARD_ACCENT_GREEN },
+                  ]}
+                />
+                <View style={historyStyles.cardContent}>
+                  <View style={historyStyles.cardTopRow}>
+                    <Text
+                      style={[
+                        historyStyles.statusText,
+                        { color: STATUS_TEXT_GREEN },
+                      ]}
+                    >
+                      Completed
+                    </Text>
+                  </View>
+
+                  <Text style={historyStyles.fieldLabel}>Pickup location</Text>
+                  <Text style={historyStyles.fieldValue}>
+                    {item.pickupLocation}
+                  </Text>
+
+                  <Text style={historyStyles.fieldLabel}>NPO Recipient</Text>
+                  <Text style={historyStyles.fieldValue}>
+                    {item.npoRecipient}
+                  </Text>
+
+                  <TouchableOpacity
+                    style={historyStyles.buttonFullWidth}
+                    activeOpacity={0.85}
+                    onPress={() => {
+                      /* Sprint 3: navigate with task id */
+                    }}
+                  >
+                    <Text style={historyStyles.buttonFullWidthText}>
+                      Edit donation details
+                    </Text>
+                  </TouchableOpacity>
+                </View>
+              </View>
+            ))}
+          </View>
+        ))
+      )}
+    </View>
+  );
+}

--- a/src/app/(tabs)/my-tasks.tsx
+++ b/src/app/(tabs)/my-tasks.tsx
@@ -99,6 +99,23 @@ function formatAddress(task: Task): string {
   return 'Address details in app';
 }
 
+function isTaskComplete(task: Task): boolean {
+  // In our mid-fi, tasks are "complete" when the backend provides an end time.
+  return task.end_time != null;
+}
+
+function isOverdue(task: Task): boolean {
+  // "Overdue" means pickup_date is before today and the task isn't complete yet.
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  // pickup_date is expected as "YYYY-MM-DD"
+  const pickup = new Date(`${task.pickup_date}T00:00:00`);
+  if (isNaN(pickup.getTime())) return false;
+
+  return pickup.getTime() < today.getTime() && !isTaskComplete(task);
+}
+
 export default function MyTasksPage() {
   const router = useRouter();
   const { driver } = useAuth();
@@ -288,7 +305,13 @@ export default function MyTasksPage() {
               <Text style={styles.sectionHeader}>TODAY ({tasks.length})</Text>
               {tasks.map(task => (
                 <View key={task.id} style={styles.card}>
-                  <View style={styles.cardAccent} />
+                  <View
+                    style={
+                      isOverdue(task)
+                        ? styles.cardAccentOverdue
+                        : styles.cardAccent
+                    }
+                  />
                   <View style={styles.cardContent}>
                     <Text style={styles.cardTitle}>
                       Pickup from {task.location_name || 'Unknown Location'}

--- a/src/app/(tabs)/my-tasks.tsx
+++ b/src/app/(tabs)/my-tasks.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import {
   ActivityIndicator,
   Image,
+  Pressable,
   RefreshControl,
   ScrollView,
   Text,
@@ -104,6 +105,7 @@ export default function MyTasksPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [segmentTab, setSegmentTab] = useState<'left' | 'right'>('left');
 
   const today = new Date().toLocaleDateString('en-US', {
     weekday: 'long',
@@ -189,14 +191,76 @@ export default function MyTasksPage() {
         <Text style={styles.greeting}>
           Welcome Back, {driver?.first_name || ''}
         </Text>
-        <Text style={styles.subtext}>
-          You have <Text style={styles.bold}>{tasks.length} tasks</Text> in
-          progress today
-        </Text>
+        {segmentTab === 'left' ? (
+          <Text style={styles.subtext}>
+            You have <Text style={styles.bold}>{tasks.length} tasks</Text> in
+            progress today
+          </Text>
+        ) : (
+          <Text style={styles.subtext}>
+            View your completed pickups and past activity.
+          </Text>
+        )}
+        <View
+          style={{
+            flexDirection: 'row',
+            backgroundColor: '#F3F4F6',
+            borderRadius: 12,
+            padding: 4,
+            marginTop: 16,
+          }}
+        >
+          <Pressable
+            style={{
+              flex: 1,
+              paddingVertical: 10,
+              paddingHorizontal: 20,
+              backgroundColor:
+                segmentTab === 'left' ? '#FFFFFF' : 'transparent',
+              borderRadius: 8,
+              alignItems: 'center',
+            }}
+            onPress={() => setSegmentTab('left')}
+          >
+            <Text
+              style={{
+                fontSize: 14,
+                fontWeight: '600',
+                color: segmentTab === 'left' ? '#06B97C' : '#9CA3AF',
+                fontFamily: 'LatoBold',
+              }}
+            >
+              In Progress
+            </Text>
+          </Pressable>
+          <Pressable
+            style={{
+              flex: 1,
+              paddingVertical: 10,
+              paddingHorizontal: 20,
+              backgroundColor:
+                segmentTab === 'right' ? '#FFFFFF' : 'transparent',
+              borderRadius: 8,
+              alignItems: 'center',
+            }}
+            onPress={() => setSegmentTab('right')}
+          >
+            <Text
+              style={{
+                fontSize: 14,
+                fontWeight: '600',
+                color: segmentTab === 'right' ? '#06B97C' : '#9CA3AF',
+                fontFamily: 'LatoBold',
+              }}
+            >
+              History
+            </Text>
+          </Pressable>
+        </View>
       </View>
 
       {/* ERROR MESSAGE */}
-      {error && (
+      {segmentTab === 'left' && error && (
         <View
           style={{
             backgroundColor: '#fee2e2',
@@ -215,7 +279,13 @@ export default function MyTasksPage() {
 
       {/* TASKS SECTION */}
       <View style={styles.taskSection}>
-        {hasTasks ? (
+        {segmentTab === 'right' ? (
+          <View style={styles.emptyStateContainer}>
+            <Text style={[styles.emptyTitle, { marginTop: 0 }]}>
+              History will show your completed pickups here.
+            </Text>
+          </View>
+        ) : hasTasks ? (
           <>
             <Text style={styles.sectionHeader}>TODAY ({tasks.length})</Text>
             {tasks.map(task => (

--- a/src/app/(tabs)/my-tasks.tsx
+++ b/src/app/(tabs)/my-tasks.tsx
@@ -15,6 +15,7 @@ import { ApiError, apiRequest, validateArrayResponse } from '~/api/apiUtils';
 import { API_ENDPOINTS, BASE_URL } from '~/api/config';
 import styles from '../../styles/tabs/my-tasks-styles';
 import { useAuth } from '../../utils/AuthContext';
+import HistoryHomeContent from './history';
 
 type Task = {
   id: number;
@@ -259,7 +260,7 @@ export default function MyTasksPage() {
         </View>
       </View>
 
-      {/* ERROR MESSAGE */}
+      {/* ERROR MESSAGE — in-progress tasks only */}
       {segmentTab === 'left' && error && (
         <View
           style={{
@@ -277,91 +278,91 @@ export default function MyTasksPage() {
         </View>
       )}
 
-      {/* TASKS SECTION */}
-      <View style={styles.taskSection}>
-        {segmentTab === 'right' ? (
-          <View style={styles.emptyStateContainer}>
-            <Text style={[styles.emptyTitle, { marginTop: 0 }]}>
-              History will show your completed pickups here.
-            </Text>
-          </View>
-        ) : hasTasks ? (
-          <>
-            <Text style={styles.sectionHeader}>TODAY ({tasks.length})</Text>
-            {tasks.map(task => (
-              <View key={task.id} style={styles.card}>
-                <View style={styles.cardAccent} />
-                <View style={styles.cardContent}>
-                  <Text style={styles.cardTitle}>
-                    Pickup from {task.location_name || 'Unknown Location'}
-                  </Text>
-                  <Text style={styles.cardAddress}>{formatAddress(task)}</Text>
-                  <Text style={styles.cardTime}>
-                    {formatTimeRange(task.start_time, task.end_time)}
-                  </Text>
+      {/* TASKS vs HISTORY */}
+      {segmentTab === 'right' ? (
+        <HistoryHomeContent />
+      ) : (
+        <View style={styles.taskSection}>
+          {hasTasks ? (
+            <>
+              <Text style={styles.sectionHeader}>TODAY ({tasks.length})</Text>
+              {tasks.map(task => (
+                <View key={task.id} style={styles.card}>
+                  <View style={styles.cardAccent} />
+                  <View style={styles.cardContent}>
+                    <Text style={styles.cardTitle}>
+                      Pickup from {task.location_name || 'Unknown Location'}
+                    </Text>
+                    <Text style={styles.cardAddress}>
+                      {formatAddress(task)}
+                    </Text>
+                    <Text style={styles.cardTime}>
+                      {formatTimeRange(task.start_time, task.end_time)}
+                    </Text>
 
-                  <View style={styles.buttonRow}>
-                    <TouchableOpacity
-                      style={[styles.button, styles.buttonOutline]}
-                      onPress={() =>
-                        router.push({
-                          pathname: '/pickup-details/[id]',
-                          params: {
-                            id: task.encrypted_id,
-                            location: task.location_name ?? '',
-                          },
-                        })
-                      }
-                    >
-                      <Text
-                        style={[styles.buttonText, styles.buttonOutlineText]}
+                    <View style={styles.buttonRow}>
+                      <TouchableOpacity
+                        style={[styles.button, styles.buttonOutline]}
+                        onPress={() =>
+                          router.push({
+                            pathname: '/pickup-details/[id]',
+                            params: {
+                              id: task.encrypted_id,
+                              location: task.location_name ?? '',
+                            },
+                          })
+                        }
                       >
-                        View pickup details
-                      </Text>
-                    </TouchableOpacity>
+                        <Text
+                          style={[styles.buttonText, styles.buttonOutlineText]}
+                        >
+                          View pickup details
+                        </Text>
+                      </TouchableOpacity>
 
-                    <TouchableOpacity
-                      style={[styles.button, styles.buttonFilled]}
-                      onPress={() =>
-                        router.push({
-                          pathname: '/donation-details/[id]',
-                          params: {
-                            id: task.encrypted_id,
-                            location: task.location_name ?? '',
-                          },
-                        })
-                      }
-                    >
-                      <Text
-                        style={[styles.buttonText, styles.buttonFilledText]}
+                      <TouchableOpacity
+                        style={[styles.button, styles.buttonFilled]}
+                        onPress={() =>
+                          router.push({
+                            pathname: '/donation-details/[id]',
+                            params: {
+                              id: task.encrypted_id,
+                              location: task.location_name ?? '',
+                            },
+                          })
+                        }
                       >
-                        Enter donation details
-                      </Text>
-                    </TouchableOpacity>
+                        <Text
+                          style={[styles.buttonText, styles.buttonFilledText]}
+                        >
+                          Enter donation details
+                        </Text>
+                      </TouchableOpacity>
+                    </View>
                   </View>
                 </View>
-              </View>
-            ))}
-          </>
-        ) : (
-          <View style={styles.emptyStateContainer}>
-            <Image
-              source={elementIcon}
-              style={styles.emptyIcon}
-              resizeMode="contain"
-            />
+              ))}
+            </>
+          ) : (
+            <View style={styles.emptyStateContainer}>
+              <Image
+                source={elementIcon}
+                style={styles.emptyIcon}
+                resizeMode="contain"
+              />
 
-            <Text style={styles.emptyTitle}>You have no new tasks</Text>
+              <Text style={styles.emptyTitle}>You have no new tasks</Text>
 
-            <TouchableOpacity
-              style={styles.emptyButton}
-              onPress={() => router.replace('/(tabs)/available-pick-ups')}
-            >
-              <Text style={styles.emptyButtonText}>Add Task</Text>
-            </TouchableOpacity>
-          </View>
-        )}
-      </View>
+              <TouchableOpacity
+                style={styles.emptyButton}
+                onPress={() => router.replace('/(tabs)/available-pick-ups')}
+              >
+                <Text style={styles.emptyButtonText}>Add Task</Text>
+              </TouchableOpacity>
+            </View>
+          )}
+        </View>
+      )}
     </ScrollView>
   );
 }

--- a/src/styles/tabs/history-styles.ts
+++ b/src/styles/tabs/history-styles.ts
@@ -1,0 +1,157 @@
+import { StyleSheet } from 'react-native';
+
+/** History tab — card layout aligned with my-tasks + mid-fi field rows */
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#ECEFF0',
+  },
+
+  headerContainer: {
+    backgroundColor: '#FFFFFF',
+    paddingHorizontal: 22,
+    paddingTop: 58,
+    paddingBottom: 20,
+    shadowColor: '#000',
+    shadowOpacity: 0.1,
+    shadowOffset: { width: 0, height: 4 },
+    shadowRadius: 10,
+    elevation: 4,
+    fontFamily: 'Lato',
+  },
+  headerTopRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  date: {
+    fontSize: 15,
+    color: '#525454',
+    fontFamily: 'Lato',
+  },
+  avatarCircle: {
+    width: 38,
+    height: 38,
+    borderRadius: 19,
+    backgroundColor: '#aeddc4',
+    borderWidth: 2,
+    borderColor: '#3ea377',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  avatarLetter: {
+    fontSize: 16,
+    color: '#3EA377',
+    fontWeight: '600',
+    fontFamily: 'LatoBold',
+  },
+  greeting: {
+    color: '#427B60',
+    textAlign: 'left',
+    fontFamily: 'LatoBold',
+    fontSize: 27,
+    marginTop: 0,
+    minHeight: 32,
+  },
+  subtext: {
+    textAlign: 'left',
+    color: '#2D8A60',
+    fontSize: 15,
+    marginTop: 12,
+    fontFamily: 'Lato',
+  },
+
+  taskSection: {
+    paddingHorizontal: 20,
+    paddingTop: 24,
+    paddingBottom: 32,
+  },
+  dateGroupHeader: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: '#151515',
+    marginBottom: 14,
+    fontFamily: 'LatoBold',
+  },
+
+  /** Same row + shadow pattern as my-tasks card */
+  card: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 18,
+    flexDirection: 'row',
+    marginBottom: 20,
+    overflow: 'hidden',
+    shadowColor: '#000',
+    shadowOpacity: 0.07,
+    shadowOffset: { width: 0, height: 6 },
+    shadowRadius: 12,
+    elevation: 6,
+  },
+  cardAccent: {
+    width: 5,
+    alignSelf: 'stretch',
+    borderTopLeftRadius: 18,
+    borderBottomLeftRadius: 18,
+  },
+  cardContent: {
+    flex: 1,
+    paddingHorizontal: 18,
+    paddingVertical: 16,
+  },
+  cardTopRow: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    alignItems: 'flex-start',
+    marginBottom: 8,
+  },
+  statusText: {
+    fontSize: 13,
+    fontWeight: '600',
+    fontFamily: 'LatoBold',
+  },
+  fieldLabel: {
+    fontSize: 12,
+    color: '#969696',
+    marginBottom: 4,
+    fontFamily: 'Lato',
+  },
+  fieldValue: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: '#151515',
+    marginBottom: 12,
+    fontFamily: 'LatoBold',
+  },
+  buttonFullWidth: {
+    marginTop: 4,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#59AF84',
+    backgroundColor: '#FFFFFF',
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: 40,
+    paddingVertical: 10,
+  },
+  buttonFullWidthText: {
+    fontSize: 13,
+    fontWeight: '700',
+    fontFamily: 'LatoBold',
+    color: '#3C7A59',
+  },
+
+  emptyStateContainer: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 48,
+    paddingHorizontal: 24,
+  },
+  emptyTitle: {
+    fontSize: 15,
+    fontFamily: 'LatoLight',
+    color: '#8F8F8F',
+    textAlign: 'center',
+  },
+});
+
+export default styles;

--- a/src/styles/tabs/my-tasks-styles.ts
+++ b/src/styles/tabs/my-tasks-styles.ts
@@ -95,6 +95,14 @@ const styles = StyleSheet.create({
     borderTopLeftRadius: 18,
     borderBottomLeftRadius: 18,
   },
+  cardAccentOverdue: {
+    width: 5,
+    backgroundColor: '#F59E0B',
+    alignSelf: 'center',
+    height: '60%',
+    borderTopLeftRadius: 18,
+    borderBottomLeftRadius: 18,
+  },
   cardContent: {
     flex: 1,
     paddingHorizontal: 18,


### PR DESCRIPTION
## What's new in this PR
### Description
Added a History screen as part of the Home page on the Replate app.

- Added a toggle between In Progress and History tasks
- Created the History screen based off of my-tasks.tsx
- Included pickupDate and isComplete on History page tasks to flag overdue tasks as yellow


### Screenshots
<img width="1206" height="2622" alt="IMG_0164" src="https://github.com/user-attachments/assets/1e2d4017-2225-4307-86d3-9156196d0cbb" />
<img width="1206" height="2622" alt="IMG_0165" src="https://github.com/user-attachments/assets/ec8015e8-8e88-4e50-b532-d36c7f93c383" />


## How to review
Review the PR commit by commit.


## Next steps
The real data connection isn't included in this sprint and will be done in Sprint 3.
N/A


## Relevant links
### Online sources
N/A


### Related PRs
N/A


CC: @jeannineruiz @stephenhungg 
