### PR TITLE
fetch real task data on donation details page (REP-41)

### DIFF
--- a/api/config.ts
+++ b/api/config.ts
@@ -261,6 +261,18 @@ export async function updateDriverPartner(
   }
 }
 
+export async function getTask(encryptedTaskId: string) {
+  const safeId = encodeURIComponent(encryptedTaskId);
+
+  return apiRequest(`${BASE_URL}${API_ENDPOINTS.TASKS}/${safeId}`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+  });
+}
+
 export async function claimTask(encryptedTaskId: string, driverId: number) {
   const safeId = encodeURIComponent(encryptedTaskId);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,7 +55,7 @@ importers:
         version: 3.0.9(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       nativewind:
         specifier: ^4.2.2
-        version: 4.2.2(react-native-reanimated@4.1.3(@babel/core@7.28.4)(react-native-worklets@0.5.1(@babel/core@7.28.4)(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.1(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-svg@15.15.3(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tailwindcss@3.4.19(yaml@2.8.2))
+        version: 4.2.2(react-native-reanimated@4.1.3(@babel/core@7.28.4)(react-native-worklets@0.5.1(@babel/core@7.28.4)(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.1(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-svg@15.12.1(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tailwindcss@3.4.19(yaml@2.8.2))
       react:
         specifier: 19.1.0
         version: 19.1.0
@@ -84,11 +84,11 @@ importers:
         specifier: ~4.16.0
         version: 4.16.0(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react-native-svg:
-        specifier: ^15.15.3
-        version: 15.15.3(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+        specifier: 15.12.1
+        version: 15.12.1(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react-native-svg-transformer:
         specifier: ^1.5.3
-        version: 1.5.3(react-native-svg@15.15.3(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(typescript@5.9.3)
+        version: 1.5.3(react-native-svg@15.12.1(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(typescript@5.9.3)
       react-native-toast-message:
         specifier: ^2.3.3
         version: 2.3.3(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -4777,8 +4777,8 @@ packages:
       react-native: '>=0.59.0'
       react-native-svg: '>=12.0.0'
 
-  react-native-svg@15.15.3:
-    resolution: {integrity: sha512-/k4KYwPBLGcx2f5d4FjE+vCScK7QOX14cl2lIASJ28u4slHHtIhL0SZKU7u9qmRBHxTCKPoPBtN6haT1NENJNA==}
+  react-native-svg@15.12.1:
+    resolution: {integrity: sha512-vCuZJDf8a5aNC2dlMovEv4Z0jjEUET53lm/iILFnFewa15b4atjVxU6Wirm6O9y6dEsdjDZVD7Q3QM4T1wlI8g==}
     peerDependencies:
       react: '*'
       react-native: '*'
@@ -10706,11 +10706,11 @@ snapshots:
 
   napi-postinstall@0.3.4: {}
 
-  nativewind@4.2.2(react-native-reanimated@4.1.3(@babel/core@7.28.4)(react-native-worklets@0.5.1(@babel/core@7.28.4)(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.1(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-svg@15.15.3(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tailwindcss@3.4.19(yaml@2.8.2)):
+  nativewind@4.2.2(react-native-reanimated@4.1.3(@babel/core@7.28.4)(react-native-worklets@0.5.1(@babel/core@7.28.4)(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.1(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-svg@15.12.1(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tailwindcss@3.4.19(yaml@2.8.2)):
     dependencies:
       comment-json: 4.6.2
       debug: 4.4.3
-      react-native-css-interop: 0.2.2(react-native-reanimated@4.1.3(@babel/core@7.28.4)(react-native-worklets@0.5.1(@babel/core@7.28.4)(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.1(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-svg@15.15.3(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tailwindcss@3.4.19(yaml@2.8.2))
+      react-native-css-interop: 0.2.2(react-native-reanimated@4.1.3(@babel/core@7.28.4)(react-native-worklets@0.5.1(@babel/core@7.28.4)(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.1(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-svg@15.12.1(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tailwindcss@3.4.19(yaml@2.8.2))
       tailwindcss: 3.4.19(yaml@2.8.2)
     transitivePeerDependencies:
       - react
@@ -11158,7 +11158,7 @@ snapshots:
 
   react-is@19.2.4: {}
 
-  react-native-css-interop@0.2.2(react-native-reanimated@4.1.3(@babel/core@7.28.4)(react-native-worklets@0.5.1(@babel/core@7.28.4)(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.1(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-svg@15.15.3(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tailwindcss@3.4.19(yaml@2.8.2)):
+  react-native-css-interop@0.2.2(react-native-reanimated@4.1.3(@babel/core@7.28.4)(react-native-worklets@0.5.1(@babel/core@7.28.4)(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.1(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-svg@15.12.1(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tailwindcss@3.4.19(yaml@2.8.2)):
     dependencies:
       '@babel/helper-module-imports': 7.28.6
       '@babel/traverse': 7.29.0
@@ -11172,7 +11172,7 @@ snapshots:
       tailwindcss: 3.4.19(yaml@2.8.2)
     optionalDependencies:
       react-native-safe-area-context: 5.6.1(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
-      react-native-svg: 15.15.3(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      react-native-svg: 15.12.1(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -11231,19 +11231,19 @@ snapshots:
       react-native-is-edge-to-edge: 1.2.1(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       warn-once: 0.1.1
 
-  react-native-svg-transformer@1.5.3(react-native-svg@15.15.3(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(typescript@5.9.3):
+  react-native-svg-transformer@1.5.3(react-native-svg@15.12.1(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(typescript@5.9.3):
     dependencies:
       '@svgr/core': 8.1.0(typescript@5.9.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))(typescript@5.9.3)
       path-dirname: 1.0.2
       react-native: 0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0)
-      react-native-svg: 15.15.3(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      react-native-svg: 15.12.1(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  react-native-svg@15.15.3(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
+  react-native-svg@15.12.1(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
       css-select: 5.2.2
       css-tree: 1.1.3

--- a/src/app/donation-details/[id].tsx
+++ b/src/app/donation-details/[id].tsx
@@ -11,12 +11,27 @@ import {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import Toast from 'react-native-toast-message';
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import { getPartners, submitCompletionDetails } from 'api/config';
+import { getPartners, getTask, submitCompletionDetails } from 'api/config';
 import dateIcon from 'assets/date.png';
 import AnimatedPressable from '@/components/AnimatedPressable';
 import PhotoUpload from '@/components/PhotoUpload/PhotoUpload';
 import RequiredInput from '@/components/RequiredInput/RequiredInput';
 import colors from '@/styles/colors';
+import { formatPickupDate, formatTimeRangeAny } from '@/utils/dateHelpers';
+
+interface TaskPickupInfo {
+  pickup_date: string | null;
+  start_time: string | null;
+  end_time: string | null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function parseOptionalString(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}
 
 export default function DonationDetailsPage() {
   const params = useLocalSearchParams<{ id?: string; location?: string }>();
@@ -26,35 +41,93 @@ export default function DonationDetailsPage() {
   const [selectedNPO, setSelectedNPO] = useState('');
   const [notes, setNotes] = useState('');
   const [loading, setLoading] = useState(false);
+  const [isFetching, setIsFetching] = useState(true);
+  const [task, setTask] = useState<TaskPickupInfo | null>(null);
   const [npoOptions, setNpoOptions] = useState<
     { label: string; value: string }[]
   >([]);
   const isFormValid = weight.trim().length > 0 && selectedNPO.trim().length > 0;
 
   useEffect(() => {
-    const fetchPartners = async () => {
-      try {
-        const partnersList = await getPartners();
-        const safe: [number, string][] = Array.isArray(partnersList)
-          ? (partnersList as unknown[]).filter(
-              (x): x is [number, string] =>
-                Array.isArray(x) &&
-                typeof x[0] === 'number' &&
-                typeof x[1] === 'string',
-            )
-          : [];
-        setNpoOptions(
-          safe.map(([id, name]) => ({ label: name, value: String(id) })),
-        );
-      } catch {
-        Toast.show({
-          type: 'error',
-          text1: 'Could not load recipients.',
-        });
-      }
+    let cancelled = false;
+
+    const loadData = async () => {
+      setIsFetching(true);
+
+      const partnersPromise = (async () => {
+        try {
+          const partnersList = await getPartners();
+          const safe: [number, string][] = Array.isArray(partnersList)
+            ? (partnersList as unknown[]).filter(
+                (x): x is [number, string] =>
+                  Array.isArray(x) &&
+                  typeof x[0] === 'number' &&
+                  typeof x[1] === 'string',
+              )
+            : [];
+          if (!cancelled) {
+            setNpoOptions(
+              safe.map(([id, name]) => ({ label: name, value: String(id) })),
+            );
+          }
+        } catch {
+          if (!cancelled) {
+            Toast.show({
+              type: 'error',
+              text1: 'Could not load recipients.',
+            });
+          }
+        }
+      })();
+
+      const taskPromise = (async () => {
+        if (!params.id) return;
+        try {
+          const data = await getTask(params.id);
+          if (cancelled || !isRecord(data)) return;
+          setTask({
+            pickup_date:
+              parseOptionalString(data.pickup_date) ??
+              parseOptionalString(data.scheduled_date),
+            start_time:
+              parseOptionalString(data.start_time) ??
+              parseOptionalString(data.activity_start_time),
+            end_time:
+              parseOptionalString(data.end_time) ??
+              parseOptionalString(data.activity_end_time),
+          });
+        } catch {
+          if (!cancelled) {
+            Toast.show({
+              type: 'error',
+              text1: 'Could not load pickup details.',
+            });
+          }
+        }
+      })();
+
+      await Promise.all([partnersPromise, taskPromise]);
+      if (!cancelled) setIsFetching(false);
     };
-    fetchPartners();
-  }, []);
+
+    loadData();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [params.id]);
+
+  const pickupTimeLabel = task
+    ? (() => {
+        const datePart = task.pickup_date
+          ? formatPickupDate(task.pickup_date)
+          : null;
+        const timePart = formatTimeRangeAny(task.start_time, task.end_time);
+        if (datePart && timePart !== 'Time TBD')
+          return `${datePart}, ${timePart}`;
+        return datePart ?? timePart;
+      })()
+    : null;
 
   const handleComplete = async () => {
     if (!params.id) return;
@@ -110,7 +183,7 @@ export default function DonationDetailsPage() {
                   resizeMode="contain"
                 />
                 <Text className="text-sm text-neutral-500 font-body text-center">
-                  Today, 10:00 AM
+                  {pickupTimeLabel ?? (isFetching ? 'Loading…' : 'Time TBD')}
                 </Text>
               </View>
               <AnimatedPressable


### PR DESCRIPTION
## Summary

Closes [REP-41](https://linear.app/calblueprint/issue/REP-41). `donation-details/[id].tsx` already received `encrypted_id` from My Tasks but never used it. This PR fetches the real task on mount and uses it to populate the pickup date/time, replacing the hardcoded `"Today, 10:00 AM"`.

**`api/config.ts`**
- Added `getTask(encryptedTaskId)` following the exact shape of `claimTask` just above it — `GET /api/tasks/:encrypted_id` with URL-encoded id and standard JSON headers.

**`src/app/donation-details/[id].tsx`**
- New `TaskPickupInfo` state + `getTask` fetch on mount, running in parallel with the existing `getPartners` call under a single `isFetching` flag (cancellation-safe via a `cancelled` ref to avoid setState-after-unmount).
- Pickup label is built from `formatPickupDate` + `formatTimeRangeAny` (from `src/utils/dateHelpers.ts`), matching the formatting pickup-details already uses. Handles the `scheduled_date` / `activity_start_time` / `activity_end_time` backend fallback keys that pickup-details handles too.
- Loading state: shows `"Loading…"` in the date slot while fetching, falls back to `"Time TBD"` if times are missing on the task.
- Toast on task fetch error, same style as the existing partners error toast.

## Base branch

Targeting `stephenhung/design-system-overhaul` because this branch builds on top of its NativeWind/getPartners rewrite of `donation-details/[id].tsx`. Should merge after that PR lands.

## REP-39 note

While checking the file, I noticed REP-39's scope (MOCK_NPOS → getPartners, `submitCompletionDetails`, wiring the Complete button) is already fully done on `stephenhung/design-system-overhaul`. REP-41 builds cleanly on top.

## Test plan

- [x] `pnpm tsc` clean
- [x] `pnpm lint:check` clean
- [x] `pnpm prettier:check` clean
- [x] husky pre-commit hook passed
- [ ] Open Enter Details on a real task from My Tasks — verify the date row shows the real pickup date + time window instead of "Today, 10:00 AM"
- [ ] Verify `"Loading…"` briefly shows while the task is fetched
- [ ] Verify recipient dropdown still populates (shouldn't regress)
- [ ] Verify Complete button still submits and redirects to My Tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)