### PR TITLE
fix apiRequest swallowing successful 204 No Content responses

### DIFF
--- a/api/apiUtils.ts
+++ b/api/apiUtils.ts
@@ -177,8 +177,15 @@ export async function apiRequest<T = unknown>(
         );
       }
 
-      // Parse successful response
-      let data = await response.json();
+      // Parse successful response. Endpoints that return 204 No Content (or
+      // any successful response with an empty body) have nothing to parse —
+      // calling response.json() on them throws SyntaxError, which then gets
+      // swallowed by callers' try/catch and silently looks like a network
+      // failure even though the request succeeded. Treat empty bodies as
+      // undefined and skip JSON parsing.
+      const contentLength = response.headers.get('content-length');
+      const hasEmptyBody = response.status === 204 || contentLength === '0';
+      let data: unknown = hasEmptyBody ? undefined : await response.json();
 
       // Sanitize response to prevent prototype pollution
       if (sanitize && typeof data === 'object' && data !== null) {
@@ -193,8 +200,10 @@ export async function apiRequest<T = unknown>(
         }
       }
 
-      // Validate response structure if validator provided
-      if (customValidator && !customValidator(data)) {
+      // Validate response structure if validator provided. Skip validation
+      // for empty-body responses — validators are written assuming a body
+      // exists, and a 204 isn't a structural failure.
+      if (!hasEmptyBody && customValidator && !customValidator(data)) {
         throw new ApiError(
           'Invalid response structure from server',
           response.status,


### PR DESCRIPTION
## Summary

\`apiRequest\` in \`api/apiUtils.ts\` calls \`response.json()\` unconditionally on a successful response. Endpoints that return \`204 No Content\` (or any 2xx with an empty body) have nothing to parse, so \`response.json()\` throws \`SyntaxError\`. That error bubbles up into the caller's \`try/catch\` and silently looks like a network failure even though the request actually succeeded.

The donation completion endpoint (\`PATCH /api/tasks/:id/update_completion_details\`) is one concrete example: the Rails controller returns \`head 204\` on success, so every successful submission was throwing inside \`apiRequest\`, getting swallowed by the caller's catch block, and either showing the user a misleading error toast OR appearing to silently work. PR #34 (REP-49 mobile photo upload) lands directly on top of this code path, so this fix unblocks the success case for the donation flow as well.

## Changes

**\`api/apiUtils.ts\`** — 13-line change to the success path inside \`apiRequest\`:
- Detect empty body via \`response.status === 204\` OR \`Content-Length: 0\`
- Set \`data = undefined\` instead of calling \`.json()\` on those responses
- Skip the \`customValidator\` for empty-body responses since validators are written assuming a body exists, and a 204 isn't a structural failure

## What this does NOT change

- No new dependencies
- No new files
- No behavior change for endpoints that return a JSON body — the \`.json()\` path still runs as before
- Sanitization still runs only on object-or-array data (\`undefined\` correctly skips it)
- Error responses (\`!response.ok\`) still go through the existing error parsing path, untouched

## Test plan

- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm lint:check\` clean
- [x] \`pnpm prettier:check\` clean
- [ ] **Manual test once paired with PR #34 + backend PR #2803:**
  1. Submit a donation completion (with or without a photo)
  2. Confirm the success toast fires (no more silent SyntaxError)
  3. Confirm redirect to \`/(tabs)/my-tasks\` happens

## Related

- Mobile companion: [#34](https://github.com/calblueprint/replate/pull/34) (REP-39/41/49 — donation details)
- Backend companion: [replate/replate-business#2803](https://github.com/replate/replate-business/pull/2803) (REP-49 backend Paperclip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)