### PR TITLE
feat: landing page entrance animations

### DIFF
--- a/src/app/landing/index.tsx
+++ b/src/app/landing/index.tsx
@@ -1,5 +1,17 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import Animated, {
+  Easing,
+  FadeInDown,
+  FadeInUp,
+  useAnimatedStyle,
+  useSharedValue,
+  withDelay,
+  withRepeat,
+  withSequence,
+  withSpring,
+  withTiming,
+} from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 // Landing page image
@@ -7,8 +19,47 @@ import REPLATE_IMAGE from '../../../assets/replate-logo.png';
 import colors from '../../styles/colors';
 import { typography } from '../../styles/typography';
 
+const AnimatedTouchable = Animated.createAnimatedComponent(TouchableOpacity);
+
 export default function LandingPage() {
   const insets = useSafeAreaInsets();
+
+  const logoScale = useSharedValue(0);
+  const logoOpacity = useSharedValue(0);
+  const logoPulse = useSharedValue(1);
+
+  useEffect(() => {
+    // fade in + spring scale from 0 -> overshoot -> settle at 1
+    logoOpacity.value = withDelay(
+      200,
+      withTiming(1, { duration: 400, easing: Easing.out(Easing.quad) }),
+    );
+    logoScale.value = withDelay(
+      200,
+      withSpring(1, { damping: 8, stiffness: 120, mass: 0.8 }),
+    );
+
+    // subtle pulse after the entrance settles (~1s in)
+    logoPulse.value = withDelay(
+      1200,
+      withRepeat(
+        withSequence(
+          withTiming(1.04, {
+            duration: 1500,
+            easing: Easing.inOut(Easing.ease),
+          }),
+          withTiming(1, { duration: 1500, easing: Easing.inOut(Easing.ease) }),
+        ),
+        -1,
+        true,
+      ),
+    );
+  }, []);
+
+  const logoAnimatedStyle = useAnimatedStyle(() => ({
+    opacity: logoOpacity.value,
+    transform: [{ scale: logoScale.value * logoPulse.value }],
+  }));
 
   return (
     <View style={styles.container}>
@@ -21,8 +72,8 @@ export default function LandingPage() {
           },
         ]}
       >
-        {/* Top Section - Image */}
-        <View style={styles.topSection}>
+        {/* Top Section - Logo */}
+        <Animated.View style={[styles.topSection, logoAnimatedStyle]}>
           <View style={styles.imageContainer}>
             <Image
               source={REPLATE_IMAGE}
@@ -30,33 +81,43 @@ export default function LandingPage() {
               resizeMode="contain"
             />
           </View>
-        </View>
+        </Animated.View>
 
         {/* Middle Section - Text */}
         <View style={styles.middleSection}>
-          <Text style={styles.welcomeText}>Welcome!</Text>
-          <Text style={styles.subtitle}>Let's sign you into your account.</Text>
+          <Animated.Text
+            entering={FadeInUp.duration(500).delay(500)}
+            style={styles.welcomeText}
+          >
+            Welcome!
+          </Animated.Text>
+          <Animated.Text
+            entering={FadeInUp.duration(500).delay(650)}
+            style={styles.subtitle}
+          >
+            Let's sign you into your account.
+          </Animated.Text>
         </View>
 
         {/* Bottom Section - Buttons */}
         <View style={styles.buttonContainer}>
-          {/* LOGIN Button - Outlined */}
-          <TouchableOpacity
+          <AnimatedTouchable
+            entering={FadeInDown.duration(400).delay(900)}
             style={styles.loginButton}
             onPress={() => router.replace('/auth/login')}
             activeOpacity={0.8}
           >
             <Text style={styles.loginButtonText}>LOGIN</Text>
-          </TouchableOpacity>
+          </AnimatedTouchable>
 
-          {/* SIGNUP Button - Filled */}
-          <TouchableOpacity
+          <AnimatedTouchable
+            entering={FadeInDown.duration(400).delay(1050)}
             style={styles.signupButton}
             onPress={() => router.replace('/auth/signup')}
             activeOpacity={0.8}
           >
             <Text style={styles.signupButtonText}>SIGNUP</Text>
-          </TouchableOpacity>
+          </AnimatedTouchable>
         </View>
       </View>
     </View>


### PR DESCRIPTION
## Summary
- adds spring-scale entrance animation on the replate logo with a subtle breathing pulse after it settles
- staggered fade-in-up for welcome text and subtitle
- staggered fade-in-down for login/signup buttons
- all animations use react-native-reanimated (already installed) and run on the native thread

## Test plan
- [ ] open the app logged out and verify the landing page animation sequence plays smoothly
- [ ] verify the logo spring bounce feels natural and the pulse is subtle
- [ ] verify text and buttons stagger in with correct timing
- [ ] test on both iOS and Android